### PR TITLE
Feature/login

### DIFF
--- a/apps/backend/src/main/java/com/solsol/heycalendar/common/ApiResponse.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/common/ApiResponse.java
@@ -14,6 +14,11 @@ public class ApiResponse<T> {
 	public static <T> ApiResponse<T> ok(T data) {
 		return new ApiResponse<>(true, "OK", "OK", data);
 	}
+
+	public static <T> ApiResponse<T> success(String message, T data) {
+		return new ApiResponse<>(true, message, "OK", data);
+	}
+
 	public static <T> ApiResponse<T> error(String message, String code) {
 		return new ApiResponse<>(false, message, code, null);
 	}

--- a/apps/backend/src/main/java/com/solsol/heycalendar/config/JwtProperties.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/config/JwtProperties.java
@@ -19,16 +19,20 @@ public class JwtProperties {
 		private String secret;
 		private int accessExpMin;
 		private int refreshExpDays;
-		private String headerString;
 		private String tokenPrefix;
+		private String headerString;
 
 
 		public void setIssuer(String s) { this.issuer = s; }
 		public void setSecret(String s) { this.secret = s; }
 		public void setAccessExpMin(int v) { this.accessExpMin = v; }
 		public void setRefreshExpDays(int v) { this.refreshExpDays = v; }
-		public void setHeaderString(String s) { this.headerString = s; }
 		public void setTokenPrefix(String s) { this.tokenPrefix = s; }
+		public void setHeaderString(String s) { this.headerString = s; }
+
+		public String getNormalizedTokenPrefix() {
+			return tokenPrefix == null ? "" : tokenPrefix.trim();
+		}
 	}
 
 	@Getter

--- a/apps/backend/src/main/java/com/solsol/heycalendar/controller/AuthController.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/controller/AuthController.java
@@ -7,25 +7,34 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.solsol.heycalendar.common.ApiResponse;
+import com.solsol.heycalendar.config.JwtProperties;
 import com.solsol.heycalendar.dto.request.AuthRequest;
 import com.solsol.heycalendar.dto.request.LogoutRequest;
 import com.solsol.heycalendar.dto.request.PasswordResetConfirmRequest;
 import com.solsol.heycalendar.dto.request.PasswordResetRequest;
-import com.solsol.heycalendar.dto.request.RefreshReqeust;
+import com.solsol.heycalendar.dto.request.RefreshRequest;
 import com.solsol.heycalendar.dto.response.AuthResponse;
 import com.solsol.heycalendar.service.AuthService;
-
-import lombok.RequiredArgsConstructor;
 
 /**
  * 인증 관련 API를 처리하는 컨트롤러입니다. (로그인, 로그아웃, 토큰 재발급)
  */
 @RestController
 @RequestMapping("/api/auth")
-@RequiredArgsConstructor
 public class AuthController {
 
 	private final AuthService authService;
+	private final JwtProperties props;
+
+	private final String headerName;
+	private final String tokenPrefix;
+
+	public AuthController(AuthService authService, JwtProperties props) {
+		this.authService = authService;
+		this.props = props;
+		this.headerName = props.getJwt().getHeaderString();
+		this.tokenPrefix = props.getJwt().getTokenPrefix();
+	}
 
 	/**
 	 * 사용자의 로그인을 처리하고, 성공 시 액세스 토큰과 리프레시 토큰을 발급합니다.
@@ -36,9 +45,11 @@ public class AuthController {
 	@PostMapping("/login")
 	public ResponseEntity<ApiResponse<AuthResponse>> login(@RequestBody AuthRequest authRequest) {
 		AuthResponse authResponse = authService.login(authRequest);
-		return ResponseEntity.ok(new ApiResponse<>(true, "Login successful.", "OK", authResponse));
-	}
 
+		return ResponseEntity.ok()
+			.header(headerName, tokenPrefix + " " + authResponse.getAccessToken())
+			.body(new ApiResponse<>(true, "Login successful.", "OK", authResponse));
+	}
 	/**
 	 * 사용자의 로그아웃을 처리합니다. 서버에 저장된 리프레시 토큰을 무효화합니다.
 	 *
@@ -58,9 +69,12 @@ public class AuthController {
 	 * @return 새로 발급된 토큰 정보를 포함하는 응답
 	 */
 	@PostMapping("/refresh")
-	public ResponseEntity<ApiResponse<AuthResponse>> refresh(@RequestBody RefreshReqeust refreshRequest) {
+	public ResponseEntity<ApiResponse<AuthResponse>> refresh(@RequestBody RefreshRequest refreshRequest) {
 		AuthResponse authResponse = authService.refresh(refreshRequest);
-		return ResponseEntity.ok(new ApiResponse<>(true, "Tokens refreshed successfully.", "OK", authResponse));
+
+		return ResponseEntity.ok()
+			.header(headerName, tokenPrefix + " " + authResponse.getAccessToken())
+			.body(new ApiResponse<>(true, "Tokens refreshed successfully.", "OK", authResponse));
 	}
 
 	/**

--- a/apps/backend/src/main/java/com/solsol/heycalendar/controller/AuthController.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/controller/AuthController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.solsol.heycalendar.common.ApiResponse;
 import com.solsol.heycalendar.dto.request.AuthRequest;
 import com.solsol.heycalendar.dto.request.LogoutRequest;
+import com.solsol.heycalendar.dto.request.PasswordResetConfirmRequest;
+import com.solsol.heycalendar.dto.request.PasswordResetRequest;
 import com.solsol.heycalendar.dto.request.RefreshReqeust;
 import com.solsol.heycalendar.dto.response.AuthResponse;
 import com.solsol.heycalendar.service.AuthService;
@@ -38,6 +40,18 @@ public class AuthController {
 	}
 
 	/**
+	 * 사용자의 로그아웃을 처리합니다. 서버에 저장된 리프레시 토큰을 무효화합니다.
+	 *
+	 * @param logoutRequest 로그아웃 요청 DTO (리프레시 토큰)
+	 * @return 작업 성공 여부를 포함하는 응답
+	 */
+	@PostMapping("/logout")
+	public ResponseEntity<ApiResponse<Void>> logout(@RequestBody LogoutRequest logoutRequest) {
+		authService.logout(logoutRequest);
+		return ResponseEntity.ok(new ApiResponse<>(true, "Logout successful.", "OK", null));
+	}
+
+	/**
 	 * 만료된 액세스 토큰을 새로운 토큰으로 재발급합니다.
 	 *
 	 * @param refreshRequest 재발급 요청 DTO (리프레시 토큰)
@@ -50,14 +64,26 @@ public class AuthController {
 	}
 
 	/**
-	 * 사용자의 로그아웃을 처리합니다. 서버에 저장된 리프레시 토큰을 무효화합니다.
+	 * 비밀번호 재설정 요청 엔드포인트입니다.
 	 *
-	 * @param logoutRequest 로그아웃 요청 DTO (리프레시 토큰)
-	 * @return 작업 성공 여부를 포함하는 응답
+	 * @param request 비밀번호 재설정 요청 DTO
+	 * @return ResponseEntity<ApiResponse<Void>>
 	 */
-	@PostMapping("/logout")
-	public ResponseEntity<ApiResponse<Void>> logout(@RequestBody LogoutRequest logoutRequest) {
-		authService.logout(logoutRequest);
-		return ResponseEntity.ok(new ApiResponse<>(true, "Logout successful.", "OK", null));
+	@PostMapping("/password/reset/request")
+	public ResponseEntity<ApiResponse<Void>> requestPasswordReset(@RequestBody PasswordResetRequest request) {
+		authService.requestPasswordReset(request);
+		return ResponseEntity.ok(ApiResponse.success("Password reset request successful", null));
+	}
+
+	/**
+	 * 비밀번호 재설정 확정 엔드포인트입니다.
+	 *
+	 * @param request 비밀번호 재설정 확정 요청 DTO
+	 * @return ResponseEntity<ApiResponse<Void>>
+	 */
+	@PostMapping("/password/reset/confirm")
+	public ResponseEntity<ApiResponse<Void>> confirmPasswordReset(@RequestBody PasswordResetConfirmRequest request) {
+		authService.confirmPasswordReset(request);
+		return ResponseEntity.ok(ApiResponse.success("Password reset successful", null));
 	}
 }

--- a/apps/backend/src/main/java/com/solsol/heycalendar/domain/RefreshToken.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/domain/RefreshToken.java
@@ -14,7 +14,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RefreshToken {
-	private Long userNm;
+	private String userNm;
 	private String userId;
 	private String token;
 	private LocalDateTime issuedAt;

--- a/apps/backend/src/main/java/com/solsol/heycalendar/domain/User.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/domain/User.java
@@ -15,6 +15,7 @@ public class User {
 	private Long userNm;
 	private String accountNm;
 	private String userId;
+	private String password;
 	private String userKey;
 	private String userName;
 	private Status status;

--- a/apps/backend/src/main/java/com/solsol/heycalendar/domain/User.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/domain/User.java
@@ -1,5 +1,6 @@
 package com.solsol.heycalendar.domain;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 import lombok.AllArgsConstructor;
@@ -20,7 +21,7 @@ public class User {
 	private String userName;
 	private Status status;
 	private int grade;
-	private double gpa;
+	private BigDecimal gpa;
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
 	private Role role;
@@ -28,5 +29,4 @@ public class User {
 	private Long deptNm;
 	private Long collegeNm;
 	private Long univNm;
-
 }

--- a/apps/backend/src/main/java/com/solsol/heycalendar/domain/User.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/domain/User.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class User {
-	private Long userNm;
+	private String userNm;
 	private String accountNm;
 	private String userId;
 	private String password;

--- a/apps/backend/src/main/java/com/solsol/heycalendar/dto/request/PasswordResetConfirmRequest.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/dto/request/PasswordResetConfirmRequest.java
@@ -1,0 +1,20 @@
+package com.solsol.heycalendar.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 비밀번호 재설정 확인 요청 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetConfirmRequest {
+
+	private String token;
+
+	private String newPassword;
+}

--- a/apps/backend/src/main/java/com/solsol/heycalendar/dto/request/PasswordResetRequest.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/dto/request/PasswordResetRequest.java
@@ -1,0 +1,14 @@
+package com.solsol.heycalendar.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetRequest {
+	private String userId;
+}

--- a/apps/backend/src/main/java/com/solsol/heycalendar/dto/request/RefreshRequest.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/dto/request/RefreshRequest.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 /**
  * 토큰 재발급 요청을 위한 DTO
@@ -13,7 +12,7 @@ import lombok.Setter;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class RefreshReqeust {
+public class RefreshRequest {
 	// 토큰 재발급에 사용할 리프레시 토큰
 	private String refreshToken;
 }

--- a/apps/backend/src/main/java/com/solsol/heycalendar/dto/response/AffiliationNamesResponse.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/dto/response/AffiliationNamesResponse.java
@@ -1,0 +1,21 @@
+package com.solsol.heycalendar.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 대학/단과대/학과 이름 매핑 결과 DTO.
+ * null 가능: 특정 ID가 없거나 매칭 실패 시 이름은 채우지 않을 수 있다.
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AffiliationNamesResponse {
+	private String universityName;
+	private String collegeName;
+	private String departmentName;
+}

--- a/apps/backend/src/main/java/com/solsol/heycalendar/exception/AuthErrorCode.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/exception/AuthErrorCode.java
@@ -1,0 +1,20 @@
+package com.solsol.heycalendar.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum  AuthErrorCode {
+	INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 잘못되었습니다."),
+	INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다."),
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다.");
+
+	private final HttpStatus status;
+	private final String message;
+
+	AuthErrorCode(HttpStatus status, String message) {
+		this.status = status;
+		this.message = message;
+	}
+
+	public HttpStatus getStatus() { return status; }
+	public String getMessage() { return message; }
+}

--- a/apps/backend/src/main/java/com/solsol/heycalendar/exception/AuthException.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/exception/AuthException.java
@@ -1,0 +1,14 @@
+package com.solsol.heycalendar.exception;
+
+public class AuthException extends RuntimeException {
+	private final AuthErrorCode errorCode;
+
+	public AuthException(AuthErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+
+	public AuthErrorCode getErrorCode() {
+		return errorCode;
+	}
+}

--- a/apps/backend/src/main/java/com/solsol/heycalendar/exception/GlobalExceptionHandler.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/exception/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.solsol.heycalendar.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(AuthException.class)
+	public ResponseEntity<?> handleAuthException(AuthException e) {
+		return ResponseEntity
+			.status(e.getErrorCode().getStatus())
+			.body(new ErrorResponse(e.getErrorCode().getMessage()));
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<?> handleGenericException(Exception e) {
+		return ResponseEntity
+			.status(500)
+			.body(new ErrorResponse("서버 내부 오류가 발생했습니다."));
+	}
+
+	record ErrorResponse(String message) {}
+}

--- a/apps/backend/src/main/java/com/solsol/heycalendar/mapper/AffiliationMapper.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/mapper/AffiliationMapper.java
@@ -1,0 +1,14 @@
+package com.solsol.heycalendar.mapper;
+
+import org.apache.ibatis.annotations.Param;
+
+public interface AffiliationMapper {
+	String findUniversityName(@Param("univNm") Long univNm);
+
+	String findCollegeName(@Param("collegeNm") Long collegeNm,
+		@Param("univNm") Long univNm);
+
+	String findDepartmentName(@Param("deptNm") Long deptNm,
+		@Param("collegeNm") Long collegeNm,
+		@Param("univNm") Long univNm);
+}

--- a/apps/backend/src/main/java/com/solsol/heycalendar/mapper/RefreshTokenMapper.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/mapper/RefreshTokenMapper.java
@@ -5,11 +5,38 @@ import org.apache.ibatis.annotations.Param;
 
 import com.solsol.heycalendar.domain.RefreshToken;
 
+/**
+ * 리프레시 토큰 저장/조회/무효화용 MyBatis 매퍼.
+ */
 @Mapper
 public interface RefreshTokenMapper {
+	/**
+	 * 리프레시 토큰 저장(JTI 기준).
+	 * @param token 토큰 엔티티
+	 * @return 삽입 행 수
+	 */
 	int insert(RefreshToken token);
-	RefreshToken findActiveByToken(@Param("token") String token);
-	int revokeByToken(@Param("token") String token);
-	int revokeAllByUser(@Param("userNm") Long userNm);
-	int touchLastUsed(@Param("token") String token);
+
+	/**
+	 * 활성 상태(만료X, 취소X)의 토큰을 JTI로 조회.
+	 * @param tokenJti 토큰 ID(JWT ID)
+	 * @return RefreshToken 또는 null
+	 */
+	RefreshToken findActiveByToken(@Param("tokenJti") String tokenJti);
+
+	/**
+	 * 토큰(JTI) 무효화.
+	 * @param tokenJti 토큰 ID
+	 * @return 변경 행 수
+	 */
+	int revokeByToken(@Param("tokenJti") String tokenJti);
+
+	/**
+	 * 특정 사용자 모든 활성 토큰 무효화 (선택 사용).
+	 * @param userNm 학번
+	 * @return 변경 행 수
+	 */
+	int revokeAllByUserNm(@Param("userNm") String userNm);
+
+	int touchLastUsed(@Param("tokenJti") String tokenJti);
 }

--- a/apps/backend/src/main/java/com/solsol/heycalendar/mapper/UserMapper.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/mapper/UserMapper.java
@@ -7,10 +7,55 @@ import org.apache.ibatis.annotations.Param;
 
 import com.solsol.heycalendar.domain.User;
 
+/**
+ * 사용자 조회/수정용 MyBatis 매퍼.
+ */
 @Mapper
 public interface UserMapper {
 	User selectByUsername(@Param("username") String name);
 	User selectByUserNm(@Param("userNm") Long id);
 	User selectByUserId(@Param("userId") String userId);
+
+	/**
+	 * userId(로그인 ID)로 사용자 단건 조회.
+	 * @param userId 로그인 ID
+	 * @return Optional<User>
+	 */
 	Optional<User> findByUserId(@Param("userId") String userId);
+
+	/**
+	 * 학번(userNm)으로 사용자 단건 조회.
+	 * @param userNm 학번
+	 * @return Optional<User>
+	 */
+	Optional<User> findByUserNm(@Param("userNm") String userNm);
+
+	Optional<User> findByUserKey(@Param("userKey") String userKey);
+
+	/**
+	 * 로그인 ID로 비밀번호 해시 수정.
+	 * @param userId 로그인 ID
+	 * @param encodedPassword 암호화된 비밀번호(BCrypt/Argon2 등)
+	 * @return 변경 행 수
+	 */
+	int updatePasswordByUserId(@Param("userId") String userId,
+		@Param("encodedPassword") String encodedPassword);
+
+	/**
+	 * 비밀번호 재설정용 임시 코드(userKey) 저장.
+	 * @param userId 로그인 ID
+	 * @param userKey 임시 코드(예: 6자리)
+	 * @return 변경 행 수
+	 */
+	int updateUserKeyByUserId(@Param("userId") String userId,
+		@Param("userKey") String userKey);
+
+	/**
+	 * 비밀번호 재설정 완료 후 userKey 제거.
+	 * @param userId 로그인 ID
+	 * @return 변경 행 수
+	 */
+	int clearUserKeyByUserId(@Param("userId") String userId);
+
+	int clearUserKeyByUserKey(@Param("userKey") String userKey);
 }

--- a/apps/backend/src/main/java/com/solsol/heycalendar/mapper/UserMapper.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/mapper/UserMapper.java
@@ -12,50 +12,16 @@ import com.solsol.heycalendar.domain.User;
  */
 @Mapper
 public interface UserMapper {
-	User selectByUsername(@Param("username") String name);
-	User selectByUserNm(@Param("userNm") Long id);
-	User selectByUserId(@Param("userId") String userId);
-
-	/**
-	 * userId(로그인 ID)로 사용자 단건 조회.
-	 * @param userId 로그인 ID
-	 * @return Optional<User>
-	 */
 	Optional<User> findByUserId(@Param("userId") String userId);
-
-	/**
-	 * 학번(userNm)으로 사용자 단건 조회.
-	 * @param userNm 학번
-	 * @return Optional<User>
-	 */
 	Optional<User> findByUserNm(@Param("userNm") String userNm);
-
 	Optional<User> findByUserKey(@Param("userKey") String userKey);
 
-	/**
-	 * 로그인 ID로 비밀번호 해시 수정.
-	 * @param userId 로그인 ID
-	 * @param encodedPassword 암호화된 비밀번호(BCrypt/Argon2 등)
-	 * @return 변경 행 수
-	 */
 	int updatePasswordByUserId(@Param("userId") String userId,
 		@Param("encodedPassword") String encodedPassword);
 
-	/**
-	 * 비밀번호 재설정용 임시 코드(userKey) 저장.
-	 * @param userId 로그인 ID
-	 * @param userKey 임시 코드(예: 6자리)
-	 * @return 변경 행 수
-	 */
 	int updateUserKeyByUserId(@Param("userId") String userId,
 		@Param("userKey") String userKey);
 
-	/**
-	 * 비밀번호 재설정 완료 후 userKey 제거.
-	 * @param userId 로그인 ID
-	 * @return 변경 행 수
-	 */
 	int clearUserKeyByUserId(@Param("userId") String userId);
-
 	int clearUserKeyByUserKey(@Param("userKey") String userKey);
 }

--- a/apps/backend/src/main/java/com/solsol/heycalendar/security/AuthTokenService.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/security/AuthTokenService.java
@@ -1,0 +1,72 @@
+package com.solsol.heycalendar.security;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import com.solsol.heycalendar.config.JwtProperties;
+import com.solsol.heycalendar.service.AffiliationService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 액세스 토큰 생성 시 대학/단과대/학과는 '이름 문자열'만 클레임에 포함한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class AuthTokenService {
+
+	private final JwtUtil jwtUtil;
+	private final JwtProperties props;
+	private final AffiliationService affiliationService;
+
+	/**
+	 * 액세스 토큰 생성
+	 * 대학/단과대/학과는 ID로 조회하여 '이름 문자열'만 클레임에 포함
+	 *
+	 * @param userNm   토큰 subject(고유 사용자 키)
+	 * @param userId   로그인 ID
+	 * @param role     권한 (예: STUDENT/STAFF/ADMIN)
+	 * @param userName 사용자 표시명
+	 * @param deptNm   학과 ID (nullable)
+	 * @param collegeNm 단과대 ID (nullable)
+	 * @param univNm   대학 ID (nullable)
+	 * @param grade    학년 (nullable)
+	 * @return 서명된 JWT(access)
+	 */
+	public String createAccessToken(String userNm, String userId, String role, String userName,
+		Long deptNm, Long collegeNm, Long univNm, Integer grade) {
+
+		Instant now = Instant.now();
+		Instant exp = now.plusSeconds(props.getJwt().getAccessExpMin() * 60L);
+
+		// 1) 이름 조회 (ID는 토큰에 싣지 않음)
+		String univName   = affiliationService.getUniversityName(univNm);
+		String collegeName= affiliationService.getCollegeName(univNm, collegeNm);
+		String deptName   = affiliationService.getDepartmentName(univNm, collegeNm, deptNm);
+
+		// 2) 클레임 조립 (조직 관련은 '이름'만)
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("userId", userId);
+		claims.put("userName", userName);
+		claims.put("role", role);
+		claims.put("typ", "access");
+		if (grade != null) claims.put("grade", grade);
+		if (univName != null)   claims.put("univName", univName);
+		if (collegeName != null)claims.put("collegeName", collegeName);
+		if (deptName != null)   claims.put("deptName", deptName);
+
+		return jwtUtil.sign(userNm, claims, Date.from(now), Date.from(exp));
+	}
+
+	public String createRefreshToken(String userNm, String jti) {
+		Instant now = Instant.now();
+		Instant exp = now.plusSeconds(props.getJwt().getRefreshExpDays() * 86400L);
+
+		Map<String, Object> claims = Map.of("typ", "refresh");
+		return jwtUtil.sign(userNm, jti, claims, Date.from(now), Date.from(exp));
+	}
+}

--- a/apps/backend/src/main/java/com/solsol/heycalendar/security/CustomUserPrincipal.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/security/CustomUserPrincipal.java
@@ -32,7 +32,7 @@ public class CustomUserPrincipal implements UserDetails {
 	 * @return 생성된 CustomUserPrincipal 객체
 	 */
 	public static CustomUserPrincipal create(User user) {
-		return new CustomUserPrincipal(user.getUserNm(), user.getUserId(), user.getUserKey(),
+		return new CustomUserPrincipal(user.getUserNm(), user.getUserId(), user.getPassword(), user.getUserName(),
 			user.getRole() != null ? user.getRole().name() : "STUDENT");
 	}
 

--- a/apps/backend/src/main/java/com/solsol/heycalendar/security/CustomUserPrincipal.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/security/CustomUserPrincipal.java
@@ -25,6 +25,11 @@ public class CustomUserPrincipal implements UserDetails {
 	private String userName;
 	private String role;
 
+	private Long deptNm;       // 학과 (BIGINT)
+	private Long collegeNm;    // 단과대학 (BIGINT)
+	private Long univNm;       // 대학교 (BIGINT)
+	private Integer grade;     // 학년 (INT)
+
 	/**
 	 * User 엔티티 객체를 기반으로 CustomUserPrincipal 객체를 생성
 	 *
@@ -33,7 +38,11 @@ public class CustomUserPrincipal implements UserDetails {
 	 */
 	public static CustomUserPrincipal create(User user) {
 		return new CustomUserPrincipal(user.getUserNm(), user.getUserId(), user.getPassword(), user.getUserName(),
-			user.getRole() != null ? user.getRole().name() : "STUDENT");
+			user.getRole() != null ? user.getRole().name() : "STUDENT",
+			user.getDeptNm(),
+			user.getCollegeNm(),
+			user.getUnivNm(),
+			user.getGrade());
 	}
 
 	@Override
@@ -48,7 +57,7 @@ public class CustomUserPrincipal implements UserDetails {
 
 	@Override
 	public String getUsername() {
-		return userId;
+		return userName;
 	}
 
 	@Override

--- a/apps/backend/src/main/java/com/solsol/heycalendar/security/CustomUserPrincipal.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/security/CustomUserPrincipal.java
@@ -19,7 +19,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class CustomUserPrincipal implements UserDetails {
-	private Long userNm;
+	private String userNm;
 	private String userId;
 	private String password;
 	private String userName;

--- a/apps/backend/src/main/java/com/solsol/heycalendar/security/JwtAuthenticationFilter.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/security/JwtAuthenticationFilter.java
@@ -74,10 +74,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	 * @return 추출된 JWT 토큰 문자열, 없거나 형식이 맞지 않으면 null
 	 */
 	private String getJwtFromRequest(HttpServletRequest request) {
-		String bearerToken = request.getHeader(jwtProperties.getJwt().getHeaderString());
-		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(jwtProperties.getJwt().getTokenPrefix())) {
-			return bearerToken.substring(jwtProperties.getJwt().getTokenPrefix().length());
-		}
-		return null;
+		String headerName = jwtProperties.getJwt().getHeaderString(); // e.g. "Authorization"
+		if (!StringUtils.hasText(headerName)) return null;
+
+		String headerVal = request.getHeader(headerName);
+		String prefix = jwtProperties.getJwt().getNormalizedTokenPrefix(); // "Bearer" → "Bearer"
+		if (!StringUtils.hasText(headerVal) || !StringUtils.hasText(prefix)) return null;
+
+		String lowerHeader = headerVal.toLowerCase();
+		String lowerPrefix = prefix.toLowerCase();
+
+		if (!lowerHeader.startsWith(lowerPrefix)) return null;
+
+		String after = headerVal.substring(prefix.length()).stripLeading(); // 공백 유연 처리
+		return after.isEmpty() ? null : after;
 	}
+
+
 }

--- a/apps/backend/src/main/java/com/solsol/heycalendar/security/JwtUtil.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/security/JwtUtil.java
@@ -1,6 +1,6 @@
 package com.solsol.heycalendar.security;
 
-import java.security.Key;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
@@ -9,8 +9,15 @@ import org.springframework.stereotype.Component;
 
 import com.solsol.heycalendar.config.JwtProperties;
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.WeakKeyException;
+import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,85 +30,58 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtUtil {
 	private final JwtProperties props;
 
-	/**
-	 * JWT 서명에 사용할 키를 생성
-	 * @return 서명 키
-	 */
-	private Key key() {
-		return Keys.hmacShaKeyFor(props.getJwt().getSecret().getBytes());
+	/** JWT 서명에 사용할 키 생성 */
+	private SecretKey key() { // ✅ 반환 타입 SecretKey
+		byte[] bytes = props.getJwt().getSecret().getBytes(StandardCharsets.UTF_8);
+		return Keys.hmacShaKeyFor(bytes); // 최소 32바이트 권장
 	}
 
-	/**
-	 * 액세스 토큰을 생성
-	 *
-	 * @param userNm 사용자 이름
-	 * @param userId 사용자 ID
-	 * @param role   사용자 역할
-	 * @return 생성된 액세스 토큰 문자열
-	 */
+	/** 액세스 토큰 생성 */
 	public String createAccessToken(Long userNm, String userId, String role) {
 		Instant now = Instant.now();
 		Instant exp = now.plusSeconds(props.getJwt().getAccessExpMin() * 60L);
+
 		return Jwts.builder()
-			.setIssuer(props.getJwt().getIssuer())
-			.setSubject(String.valueOf(userNm))
-			.addClaims(Map.of("userId", userId, "role", role, "typ", "access"))
-			.setIssuedAt(Date.from(now))
-			.setExpiration(Date.from(exp))
-			.signWith(key(), SignatureAlgorithm.HS256)
+			.issuer(props.getJwt().getIssuer())
+			.subject(String.valueOf(userNm))
+			.claims(Map.of("userId", userId, "role", role, "typ", "access"))
+			.issuedAt(Date.from(now))
+			.expiration(Date.from(exp))
+			.signWith(key(), Jwts.SIG.HS256) // ✅ 0.12.x
 			.compact();
 	}
 
-	/**
-	 * 리프레시 토큰을 생성
-	 *
-	 * @param userNm 사용자 이름
-	 * @param jti    JWT 고유 식별자 (JTI)
-	 * @return 생성된 리프레시 토큰 문자열
-	 */
+	/** 리프레시 토큰 생성 */
 	public String createRefreshToken(Long userNm, String jti) {
 		Instant now = Instant.now();
 		Instant exp = now.plusSeconds(props.getJwt().getRefreshExpDays() * 86400L);
+
 		return Jwts.builder()
-			.setIssuer(props.getJwt().getIssuer())
-			.setSubject(String.valueOf(userNm))
-			.setId(jti)
-			.addClaims(Map.of("typ", "refresh"))
-			.setIssuedAt(Date.from(now))
-			.setExpiration(Date.from(exp))
-			.signWith(key(), SignatureAlgorithm.HS256)
+			.issuer(props.getJwt().getIssuer())
+			.subject(String.valueOf(userNm))
+			.id(jti)
+			.claims(Map.of("typ", "refresh"))
+			.issuedAt(Date.from(now))
+			.expiration(Date.from(exp))
+			.signWith(key(), Jwts.SIG.HS256) // ✅
 			.compact();
 	}
 
-	/**
-	 * 토큰을 파싱하여 JWS(JSON Web Signature) Claims 객체를 반환
-	 *
-	 * @param token 파싱할 토큰 문자열
-	 * @return 파싱된 JWS Claims 객체
-	 */
+	/** 서명된 JWS 파싱 */
 	public Jws<Claims> parse(String token) {
-		return Jwts.parserBuilder().setSigningKey(key()).build().parseClaimsJws(token);
+		return Jwts.parser()
+			.verifyWith(key()) // ✅ SecretKey 필요
+			.build()
+			.parseSignedClaims(token);
 	}
 
-	/**
-	 * 토큰에서 사용자 ID를 추출
-	 *
-	 * @param token 토큰 문자열
-	 * @return 추출된 사용자 ID
-	 */
 	public String extractUserId(String token) {
-		return parse(token).getBody().get("userId", String.class);
+		return parse(token).getPayload().get("userId", String.class); // ✅ getPayload()
 	}
 
-	/**
-	 * 토큰의 만료 여부를 확인
-	 *
-	 * @param token 토큰 문자열
-	 * @return 만료되었으면 true, 아니면 false
-	 */
 	public boolean isTokenExpired(String token) {
 		try {
-			return parse(token).getBody().getExpiration().before(new Date());
+			return parse(token).getPayload().getExpiration().before(new Date()); // ✅
 		} catch (ExpiredJwtException e) {
 			return true;
 		} catch (Exception e) {
@@ -109,12 +89,6 @@ public class JwtUtil {
 		}
 	}
 
-	/**
-	 * 토큰의 유효성을 검증 (서명, 만료일 등)
-	 *
-	 * @param token 검증할 토큰 문자열
-	 * @return 유효하면 true, 아니면 false
-	 */
 	public boolean validateToken(String token) {
 		try {
 			parse(token);
@@ -127,38 +101,21 @@ public class JwtUtil {
 			log.info("Unsupported JWT Token", e);
 		} catch (IllegalArgumentException e) {
 			log.info("JWT claims string is empty.", e);
+		} catch (WeakKeyException e) {
+			log.warn("Weak JWT Secret Key.", e);
 		}
 		return false;
 	}
 
-	/**
-	 * 토큰이 액세스 토큰인지 확인
-	 *
-	 * @param token 토큰 문자열
-	 * @return 액세스 토큰이면 true, 아니면 false
-	 */
 	public boolean isAccess(String token) {
-		return "access".equals(parse(token).getBody().get("typ", String.class));
+		return "access".equals(parse(token).getPayload().get("typ", String.class)); // ✅
 	}
 
-	/**
-	 * 토큰이 리프레시 토큰인지 확인
-	 *
-	 * @param token 토큰 문자열
-	 * @return 리프레시 토큰이면 true, 아니면 false
-	 */
 	public boolean isRefresh(String token) {
-		return "refresh".equals(parse(token).getBody().get("typ", String.class));
+		return "refresh".equals(parse(token).getPayload().get("typ", String.class)); // ✅
 	}
 
-	/**
-	 * 토큰의 subject(사용자 이름)를 추출
-	 *
-	 * @param token 토큰 문자열
-	 * @return 추출된 사용자 이름 (Long 타입)
-	 */
 	public Long subjectUserNm(String token) {
-		return Long.valueOf(parse(token).getBody().getSubject());
+		return Long.valueOf(parse(token).getPayload().getSubject());
 	}
-
 }

--- a/apps/backend/src/main/java/com/solsol/heycalendar/security/JwtUtil.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/security/JwtUtil.java
@@ -41,34 +41,28 @@ public class JwtUtil {
 	}
 	private SecretKey key() { return this.secretKey; }
 
-	/** 액세스 토큰 생성 */
-	public String createAccessToken(String userNm, String userId, String role) {
-		Instant now = Instant.now();
-		Instant exp = now.plusSeconds(props.getJwt().getAccessExpMin() * 60L);
-
+	// (1) Access Token 등 jti 없이 서명할 때 사용
+	public String sign(String subject, Map<String, Object> claims, Date issuedAt, Date expiration) {
 		return Jwts.builder()
 			.issuer(props.getJwt().getIssuer())
-			.subject(userNm)
-			.claims(Map.of("userId", userId, "role", role, "typ", "access"))
-			.issuedAt(Date.from(now))
-			.expiration(Date.from(exp))
-			.signWith(key(), Jwts.SIG.HS256) // ✅ 0.12.x
+			.subject(subject)
+			.claims(claims)
+			.issuedAt(issuedAt)
+			.expiration(expiration)
+			.signWith(key(), Jwts.SIG.HS256)
 			.compact();
 	}
 
-	/** 리프레시 토큰 생성 */
-	public String createRefreshToken(String userNm, String jti) {
-		Instant now = Instant.now();
-		Instant exp = now.plusSeconds(props.getJwt().getRefreshExpDays() * 86400L);
-
+	// (2) Refresh Token 등 jti가 필요한 경우 사용
+	public String sign(String subject, String jti, Map<String, Object> claims, Date issuedAt, Date expiration) {
 		return Jwts.builder()
 			.issuer(props.getJwt().getIssuer())
-			.subject(userNm)
-			.id(jti)
-			.claims(Map.of("typ", "refresh"))
-			.issuedAt(Date.from(now))
-			.expiration(Date.from(exp))
-			.signWith(key(), Jwts.SIG.HS256) // ✅
+			.subject(subject)
+			.id(jti) // jti 설정
+			.claims(claims)
+			.issuedAt(issuedAt)
+			.expiration(expiration)
+			.signWith(key(), Jwts.SIG.HS256)
 			.compact();
 	}
 

--- a/apps/backend/src/main/java/com/solsol/heycalendar/service/AffiliationService.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/service/AffiliationService.java
@@ -1,0 +1,33 @@
+package com.solsol.heycalendar.service;
+
+import com.solsol.heycalendar.mapper.AffiliationMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+/**
+ * 대학/단과대/학과 ID를 이름으로 매핑하는 서비스.
+ * 이름만 필요하므로 조회 후 문자열만 반환한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class AffiliationService {
+
+	private final AffiliationMapper mapper;
+
+	@Cacheable(value = "univName", key = "#univNm", unless = "#result == null")
+	public String getUniversityName(Long univNm) {
+		return (univNm == null) ? null : mapper.findUniversityName(univNm);
+	}
+
+	@Cacheable(value = "collegeName", key = "#univNm + ':' + #collegeNm", unless = "#result == null")
+	public String getCollegeName(Long univNm, Long collegeNm) {
+		return (univNm == null || collegeNm == null) ? null : mapper.findCollegeName(collegeNm, univNm);
+	}
+
+	@Cacheable(value = "deptName", key = "#univNm + ':' + #collegeNm + ':' + #deptNm", unless = "#result == null")
+	public String getDepartmentName(Long univNm, Long collegeNm, Long deptNm) {
+		return (univNm == null || collegeNm == null || deptNm == null) ? null :
+			mapper.findDepartmentName(deptNm, collegeNm, univNm);
+	}
+}

--- a/apps/backend/src/main/java/com/solsol/heycalendar/service/AuthService.java
+++ b/apps/backend/src/main/java/com/solsol/heycalendar/service/AuthService.java
@@ -63,7 +63,7 @@ public class AuthService {
 		String jti = UUID.randomUUID().toString();
 		String refreshTokenString = jwtUtil.createRefreshToken(principal.getUserNm(), jti);
 
-		Claims refreshClaims = jwtUtil.parse(refreshTokenString).getBody();
+		Claims refreshClaims = jwtUtil.parse(refreshTokenString).getPayload();
 
 		HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
 
@@ -116,7 +116,7 @@ public class AuthService {
 		String newJti = UUID.randomUUID().toString();
 		String newRefreshTokenString = jwtUtil.createRefreshToken(user.getUserNm(), newJti);
 
-		Claims newRefreshClaims = jwtUtil.parse(newRefreshTokenString).getBody();
+		Claims newRefreshClaims = jwtUtil.parse(newRefreshTokenString).getPayload();
 
 		HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
 
@@ -152,7 +152,7 @@ public class AuthService {
 
 		try {
 			if (jwtUtil.validateToken(refreshTokenString) && jwtUtil.isRefresh(refreshTokenString)) {
-				String jti = jwtUtil.parse(refreshTokenString).getBody().getId();
+				String jti = jwtUtil.parse(refreshTokenString).getPayload().getId();
 				refreshTokenMapper.revokeByToken(jti);
 			}
 		} catch (Exception e) {

--- a/apps/backend/src/main/resources/mappers/AffiliationMapper.xml
+++ b/apps/backend/src/main/resources/mappers/AffiliationMapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.solsol.heycalendar.mapper.AffiliationMapper">
+
+    <select id="findUniversityName" parameterType="long" resultType="string">
+        SELECT univName
+        FROM University
+        WHERE univNm = #{univNm}
+    </select>
+
+    <select id="findCollegeName" resultType="string">
+        SELECT name
+        FROM College
+        WHERE collegeNm = #{collegeNm}
+        AND univNm = #{univNm}
+    </select>
+
+    <select id="findDepartmentName" resultType="string">
+        SELECT name
+        FROM Department
+        WHERE deptNm = #{deptNm}
+        AND collegeNm = #{collegeNm}
+        AND univNm = #{univNm}
+    </select>
+
+</mapper>

--- a/apps/backend/src/main/resources/mappers/RefreshTokenMapper.xml
+++ b/apps/backend/src/main/resources/mappers/RefreshTokenMapper.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.solsol.heycalendar.mapper.RefreshTokenMapper">
+
+    <sql id="Refresh_Columns">
+        `id`,
+    `userNm`,
+    `userId`,
+    `token`,
+    `issuedAt`,
+    `expiresAt`,
+    `revoked`,
+    `userAgent`,
+    `ip`,
+    `rotatedFrom`
+    </sql>
+
+    <resultMap id="RefreshTokenResultMap" type="com.solsol.heycalendar.domain.RefreshToken">
+        <id     property="id"        column="id"/>
+        <result property="userNm"     column="userNm"/>
+        <result property="userId"     column="userId"/>
+        <result property="token"      column="token"/>
+        <result property="issuedAt"   column="issuedAt"  javaType="java.time.LocalDateTime"/>
+        <result property="expiresAt"  column="expiresAt" javaType="java.time.LocalDateTime"/>
+        <result property="revoked"    column="revoked"   javaType="boolean"/>
+        <result property="userAgent"  column="userAgent"/>
+        <result property="ip"         column="ip"/>
+        <result property="rotatedFrom" column="rotatedFrom"/>
+    </resultMap>
+
+    <insert id="insert" parameterType="com.solsol.heycalendar.domain.RefreshToken" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO `refresh_token` (
+            `userNm`, `userId`, `token`, `issuedAt`, `expiresAt`, `revoked`, `userAgent`, `ip`, `rotatedFrom`
+        ) VALUES (
+                     #{userNm}, #{userId}, #{token},
+                     #{issuedAt}, #{expiresAt}, #{revoked},
+                     #{userAgent}, #{ip}, #{rotatedFrom}
+                 )
+    </insert>
+
+    <select id="findActiveByToken" parameterType="string" resultMap="RefreshTokenResultMap">
+        SELECT
+        <include refid="Refresh_Columns"/>
+        FROM `refresh_token`
+        WHERE `token` = #{tokenJti}
+        AND `revoked` = 0
+        AND `expiresAt` > NOW()
+        LIMIT 1
+    </select>
+
+    <update id="revokeByToken" parameterType="string">
+        UPDATE `refresh_token`
+        SET `revoked` = 1
+        WHERE `token` = #{tokenJti}
+    </update>
+
+    <update id="revokeAllByUserNm" parameterType="string">
+        UPDATE `refresh_token`
+        SET `revoked` = 1
+        WHERE `userNm` = #{userNm}
+          AND `revoked` = 0
+    </update>
+    <!-- 마지막 사용 시각 업데이트 -->
+    <update id="touchLastUsed" parameterType="string">
+        UPDATE `refresh_token`
+        SET `lastUsedAt` = NOW()
+        WHERE `token` = #{tokenJti}
+    </update>
+
+</mapper>

--- a/apps/backend/src/main/resources/mappers/UserMapper.xml
+++ b/apps/backend/src/main/resources/mappers/UserMapper.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.solsol.heycalendar.mapper.UserMapper">
+
+    <!-- 공통 컬럼 리스트 -->
+    <sql id="User_Columns">
+        `userNm`,
+    `userMileage`,
+    `accountNm`,
+    `userId`,
+    `password`,
+    `userKey`,
+    `userName`,
+    `state`,
+    `grade`,
+    `gpa`,
+    `createdAt`,
+    `updatedAt`,
+    `role`,
+    `deptNm`,
+    `collegeNm`,
+    `univNm`
+    </sql>
+
+    <!-- ResultMap: ENUM과 LocalDateTime 자동 매핑(기본 TypeHandler 사용) -->
+    <resultMap id="UserResultMap" type="com.solsol.heycalendar.domain.User">
+        <id     property="userNm"      column="userNm"/>
+        <result property="userMileage" column="userMileage"/>
+        <result property="accountNm"   column="accountNm"/>
+        <result property="userId"      column="userId"/>
+        <result property="password"    column="password"/>
+        <result property="userKey"     column="userKey"/>
+        <result property="userName"    column="userName"/>
+        <result property="state"       column="state"    javaType="com.solsol.heycalendar.domain.Status"/>
+        <result property="grade"       column="grade"/>
+        <result property="gpa"         column="gpa"      javaType="java.math.BigDecimal"/>
+        <result property="createdAt"   column="createdAt" javaType="java.time.LocalDateTime"/>
+        <result property="updatedAt"   column="updatedAt" javaType="java.time.LocalDateTime"/>
+        <result property="role"        column="role"     javaType="com.solsol.heycalendar.domain.Role"/>
+        <result property="deptNm"      column="deptNm"/>
+        <result property="collegeNm"   column="collegeNm"/>
+        <result property="univNm"      column="univNm"/>
+    </resultMap>
+
+    <!-- userId로 단건 조회 -->
+    <select id="findByUserId" parameterType="string" resultMap="UserResultMap">
+        SELECT
+        <include refid="User_Columns"/>
+        FROM `User`
+        WHERE `userId` = #{userId}
+        LIMIT 1
+    </select>
+
+    <!-- userNm(학번)로 단건 조회 -->
+    <select id="findByUserNm" parameterType="string" resultMap="UserResultMap">
+        SELECT
+        <include refid="User_Columns"/>
+        FROM `User`
+        WHERE `userNm` = #{userNm}
+        LIMIT 1
+    </select>
+
+    <!-- 비밀번호 해시 수정 -->
+    <update id="updatePasswordByUserId">
+        UPDATE `User`
+        SET
+            `password` = #{encodedPassword},
+            `updatedAt` = CURRENT_TIMESTAMP
+        WHERE `userId` = #{userId}
+    </update>
+
+    <!-- 비밀번호 재설정용 코드 저장 -->
+    <update id="updateUserKeyByUserId">
+        UPDATE `User`
+        SET
+            `userKey` = #{userKey},
+            `updatedAt` = CURRENT_TIMESTAMP
+        WHERE `userId` = #{userId}
+    </update>
+
+    <!-- 비밀번호 재설정 완료 후 코드 제거 -->
+    <update id="clearUserKeyByUserId">
+        UPDATE `User`
+        SET
+            `userKey` = NULL,
+            `updatedAt` = CURRENT_TIMESTAMP
+        WHERE `userId` = #{userId}
+    </update>
+
+    <!-- 🔹 userKey로 단건 조회 -->
+    <select id="findByUserKey" parameterType="string" resultMap="UserResultMap">
+        SELECT
+        <include refid="User_Columns"/>
+        FROM `User`
+        WHERE `userKey` = #{userKey}
+        LIMIT 1
+    </select>
+
+    <!-- 🔹 userKey로 토큰 제거 -->
+    <update id="clearUserKeyByUserKey">
+        UPDATE `User`
+        SET
+            `userKey` = NULL,
+            `updatedAt` = CURRENT_TIMESTAMP
+        WHERE `userKey` = #{userKey}
+    </update>
+
+</mapper>

--- a/apps/backend/src/main/resources/static/University.sql
+++ b/apps/backend/src/main/resources/static/University.sql
@@ -1,0 +1,25 @@
+CREATE TABLE `University` (
+    `univNm` BIGINT NOT NULL,
+    `univName` VARCHAR(255) NULL,
+    `mileageRatio` DOUBLE NULL,
+    PRIMARY KEY (`univNm`)
+);
+
+CREATE TABLE `College` (
+    `collegeNm` BIGINT NOT NULL,
+    `univNm` BIGINT NOT NULL,
+    `name` VARCHAR(255) NULL,
+    PRIMARY KEY (`collegeNm`, `univNm`),
+    CONSTRAINT `FK_University_TO_College_1` FOREIGN KEY (`univNm`)
+        REFERENCES `University` (`univNm`)
+);
+
+CREATE TABLE `Department` (
+    `deptNm` BIGINT NOT NULL,
+    `collegeNm` BIGINT NOT NULL,
+    `univNm` BIGINT NOT NULL,
+    `name` VARCHAR(255) NULL,
+    PRIMARY KEY (`deptNm`, `collegeNm`, `univNm`),
+    CONSTRAINT `FK_College_TO_Department_1` FOREIGN KEY (`collegeNm`, `univNm`)
+        REFERENCES `College` (`collegeNm`, `univNm`)
+);

--- a/apps/backend/src/main/resources/static/User.sql
+++ b/apps/backend/src/main/resources/static/User.sql
@@ -1,0 +1,39 @@
+CREATE TABLE `User` (
+                        `userNm`       VARCHAR(20) NOT NULL, -- 학번(문자형), PK
+                        `userMileage`  INT NULL,
+                        `accountNm`    VARCHAR(100) NULL,
+                        `userId`       VARCHAR(100) NULL,  -- 로그인 ID라면 UNIQUE 권장
+                        `password`     VARCHAR(255) NOT NULL,
+                        `userKey`      VARCHAR(100) NULL,
+                        `userName`     VARCHAR(100) NULL,
+                        `state`        ENUM('ENROLLED','LEAVE_OF_ABSENCE','GRADUATED','EXPELLED') NULL,
+                        `grade`        INT NULL,
+                        `gpa`          DECIMAL(3,2) NULL,
+                        `createdAt`    DATETIME DEFAULT CURRENT_TIMESTAMP,
+                        `updatedAt`    DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                        `role`         ENUM('ADMIN','STUDENT','STAFF') NULL,
+                        `deptNm`       BIGINT NOT NULL,
+                        `collegeNm`    BIGINT NOT NULL,
+                        `univNm`       BIGINT NOT NULL,
+                        PRIMARY KEY (`userNm`),
+                        UNIQUE KEY `UK_User_userId` (`userId`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+
+CREATE TABLE `refresh_token` (
+                                 `id` BIGINT NOT NULL AUTO_INCREMENT,
+                                 `userNm` VARCHAR(20) NOT NULL,
+                                 `userId` VARCHAR(100) NOT NULL,
+                                 `token` VARCHAR(64) NOT NULL,              -- JTI
+                                 `issuedAt` DATETIME NOT NULL,
+                                 `expiresAt` DATETIME NOT NULL,
+                                 `revoked` TINYINT(1) NOT NULL DEFAULT 0,
+                                 `userAgent` VARCHAR(255) NULL,
+                                 `ip` VARCHAR(64) NULL,
+                                 `rotatedFrom` VARCHAR(64) NULL,
+                                 `lastUsedAt` DATETIME NULL,
+                                 PRIMARY KEY (`id`),
+                                 UNIQUE KEY `UK_refresh_token_token` (`token`),
+                                 KEY `IDX_refresh_userNm` (`userNm`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+CREATE INDEX IDX_User_userKey ON `User` (`userKey`);

--- a/apps/backend/src/main/resources/static/User.sql
+++ b/apps/backend/src/main/resources/static/User.sql
@@ -21,19 +21,20 @@ CREATE TABLE `User` (
 
 
 CREATE TABLE `refresh_token` (
-                                 `id` BIGINT NOT NULL AUTO_INCREMENT,
-                                 `userNm` VARCHAR(20) NOT NULL,
-                                 `userId` VARCHAR(100) NOT NULL,
-                                 `token` VARCHAR(64) NOT NULL,              -- JTI
-                                 `issuedAt` DATETIME NOT NULL,
-                                 `expiresAt` DATETIME NOT NULL,
-                                 `revoked` TINYINT(1) NOT NULL DEFAULT 0,
-                                 `userAgent` VARCHAR(255) NULL,
-                                 `ip` VARCHAR(64) NULL,
-                                 `rotatedFrom` VARCHAR(64) NULL,
-                                 `lastUsedAt` DATETIME NULL,
-                                 PRIMARY KEY (`id`),
-                                 UNIQUE KEY `UK_refresh_token_token` (`token`),
-                                 KEY `IDX_refresh_userNm` (`userNm`)
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `userNm` VARCHAR(20) NOT NULL,
+    `userId` VARCHAR(100) NOT NULL,
+    `token` VARCHAR(64) NOT NULL,              -- JTI
+    `issuedAt` DATETIME NOT NULL,
+    `expiresAt` DATETIME NOT NULL,
+    `revoked` TINYINT(1) NOT NULL DEFAULT 0,
+    `userAgent` VARCHAR(255) NULL,
+    `ip` VARCHAR(64) NULL,
+    `rotatedFrom` VARCHAR(64) NULL,
+    `lastUsedAt` DATETIME NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `UK_refresh_token_token` (`token`),
+    KEY `IDX_refresh_userNm` (`userNm`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 CREATE INDEX IDX_User_userKey ON `User` (`userKey`);

--- a/apps/backend/src/test/java/com/solsol/heycalendar/controller/AuthControllerTest.java
+++ b/apps/backend/src/test/java/com/solsol/heycalendar/controller/AuthControllerTest.java
@@ -1,0 +1,60 @@
+package com.solsol.heycalendar.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solsol.heycalendar.dto.request.AuthRequest;
+import com.solsol.heycalendar.dto.response.AuthResponse;
+import com.solsol.heycalendar.security.JwtAuthenticationFilter; // ← 실제 경로로
+import com.solsol.heycalendar.service.AuthService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.FilterType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+	controllers = AuthController.class,
+	excludeAutoConfiguration = { SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class },
+	excludeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = com.solsol.heycalendar.config.SecurityConfig.class)
+)
+@AutoConfigureMockMvc(addFilters = false) // 시큐리티 필터 체인 비활성화
+class AuthControllerTest {
+
+	@Autowired MockMvc mockMvc;
+	@Autowired ObjectMapper objectMapper;
+
+	@MockBean AuthService authService;
+
+	// ✅ 필터 자체를 MockBean으로 등록해서 빈 생성 시 의존성( JwtUtil 등 )을 타지 않게 함
+	@MockBean JwtAuthenticationFilter jwtAuthenticationFilter;
+
+	@Test
+	@DisplayName("로그인 성공 시 200과 토큰 반환")
+	void login_success() throws Exception {
+		AuthRequest req = AuthRequest.builder()
+			.userId("alice")
+			.password("password1!")
+			.build();
+
+		Mockito.when(authService.login(any()))
+			.thenReturn(new AuthResponse("ACCESS_TOKEN_EXAMPLE", "REFRESH_TOKEN_EXAMPLE"));
+
+		mockMvc.perform(post("/api/auth/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(req)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.accessToken").value("ACCESS_TOKEN_EXAMPLE"))
+			.andExpect(jsonPath("$.data.refreshToken").value("REFRESH_TOKEN_EXAMPLE"));
+	}
+}

--- a/apps/backend/src/test/java/com/solsol/heycalendar/controller/AuthControllerTest.java
+++ b/apps/backend/src/test/java/com/solsol/heycalendar/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.solsol.heycalendar.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solsol.heycalendar.config.JwtProperties;
 import com.solsol.heycalendar.dto.request.AuthRequest;
 import com.solsol.heycalendar.dto.response.AuthResponse;
 import com.solsol.heycalendar.security.JwtAuthenticationFilter; // ← 실제 경로로
@@ -11,9 +12,12 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.context.annotation.ComponentScan.Filter;
@@ -24,11 +28,32 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(
 	controllers = AuthController.class,
-	excludeAutoConfiguration = { SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class },
-	excludeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = com.solsol.heycalendar.config.SecurityConfig.class)
+	excludeAutoConfiguration = {
+		SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class
+	},
+	excludeFilters = @Filter(
+		type = FilterType.ASSIGNABLE_TYPE,
+		classes = com.solsol.heycalendar.config.SecurityConfig.class
+	)
 )
 @AutoConfigureMockMvc(addFilters = false) // 시큐리티 필터 체인 비활성화
+@Import(AuthControllerTest.TestJwtPropsConfig.class)
 class AuthControllerTest {
+
+	@TestConfiguration
+	static class TestJwtPropsConfig {
+		@Bean
+		JwtProperties jwtProperties() {
+			JwtProperties p = new JwtProperties();
+			p.getJwt().setHeaderString("Authorization");
+			p.getJwt().setTokenPrefix("Bearer");
+			// 필요하면 만료/issuer 등도 세팅 가능
+			p.getJwt().setIssuer("heycalendar");
+			p.getJwt().setAccessExpMin(30);
+			p.getJwt().setRefreshExpDays(7);
+			return p;
+		}
+	}
 
 	@Autowired MockMvc mockMvc;
 	@Autowired ObjectMapper objectMapper;

--- a/apps/backend/src/test/java/com/solsol/heycalendar/security/AuthTokenServiceTest.java
+++ b/apps/backend/src/test/java/com/solsol/heycalendar/security/AuthTokenServiceTest.java
@@ -1,0 +1,59 @@
+package com.solsol.heycalendar.security;
+
+import com.solsol.heycalendar.config.JwtProperties;
+import com.solsol.heycalendar.service.AffiliationService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class AuthTokenServiceTest {
+
+	@Test
+	@DisplayName("AccessToken: 한글 대학/단과대/학과 이름 클레임 포함 + 콘솔 출력")
+	void accessToken_containsKoreanNames_and_printToConsole() {
+		// 1) AffiliationService 스텁 (ID -> 한글 이름 매핑)
+		AffiliationService aff = mock(AffiliationService.class);
+		when(aff.getUniversityName(1001L)).thenReturn("서울대학교");
+		when(aff.getCollegeName(1001L, 2001L)).thenReturn("공과대학");
+		when(aff.getDepartmentName(1001L, 2001L, 3001L)).thenReturn("컴퓨터공학과");
+
+		// 2) JwtProperties 설정 (32바이트 이상 시크릿)
+		JwtProperties props = new JwtProperties();
+		props.getJwt().setSecret("mySecretKey1234567890abcdefghijklmnopqrstuvwxyz");
+		props.getJwt().setIssuer("heycalendar");
+		props.getJwt().setAccessExpMin(10);
+		props.getJwt().setRefreshExpDays(7);
+
+		// 3) JwtUtil(Service)을 직접 생성/초기화
+		JwtUtil jwtUtil = new JwtUtil(props);
+		jwtUtil.init();
+
+		// 4) 실제 AuthTokenService 생성
+		AuthTokenService tokenService = new AuthTokenService(jwtUtil, props, aff);
+
+		// 5) 액세스 토큰 생성 (ID 전달 → 내부에서 한글 이름으로 변환)
+		String token = tokenService.createAccessToken(
+			"20250001", "alice", "STUDENT", "홍길동",
+			3001L, 2001L, 1001L, 2
+		);
+		System.out.println("생성된 Access Token: " + token);
+
+		// 6) 파싱 후 클레임 콘솔 출력 & 검증
+		Jws<Claims> jws = jwtUtil.parse(token);
+		Claims claims = jws.getPayload();
+		System.out.println("디코드된 클레임: " + claims);
+
+		assertThat(claims.get("typ", String.class)).isEqualTo("access");
+		assertThat(claims.get("userId", String.class)).isEqualTo("alice");
+		assertThat(claims.get("userName", String.class)).isEqualTo("홍길동");
+		assertThat(claims.get("role", String.class)).isEqualTo("STUDENT");
+		assertThat(claims.get("univName", String.class)).isEqualTo("서울대학교");
+		assertThat(claims.get("collegeName", String.class)).isEqualTo("공과대학");
+		assertThat(claims.get("deptName", String.class)).isEqualTo("컴퓨터공학과");
+		assertThat(claims.get("grade", Integer.class)).isEqualTo(2);
+	}
+}

--- a/apps/backend/src/test/java/com/solsol/heycalendar/security/JwtUtilTest.java
+++ b/apps/backend/src/test/java/com/solsol/heycalendar/security/JwtUtilTest.java
@@ -1,0 +1,189 @@
+package com.solsol.heycalendar.security;
+
+import com.solsol.heycalendar.config.JwtProperties;
+import com.solsol.heycalendar.service.AffiliationService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.WeakKeyException;
+import org.junit.jupiter.api.*;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * JwtUtil은 이제 '서명/파싱/검증'만 담당.
+ * 토큰 생성은 AuthTokenService를 통해 수행한다.
+ */
+class JwtUtilTest {
+
+	private JwtUtil jwtUtil;
+	private JwtProperties props;
+
+	// HS256 권장: 32바이트(256bit) 이상 시크릿
+	private static final String STRONG_SECRET =
+		"ThisIsAStrongSecretKey_ForHS256_AtLeast32Bytes_Long_2025_heycalendar";
+
+	// 공통 ID 샘플
+	private static final Long UNIV_ID = 1001L;
+	private static final Long COLLEGE_ID = 2001L;
+	private static final Long DEPT_ID = 3001L;
+
+	// 한글 이름 매핑 결과
+	private static final String UNIV_NAME = "서울대학교";
+	private static final String COLLEGE_NAME = "공과대학";
+	private static final String DEPT_NAME = "컴퓨터공학과";
+
+	@BeforeEach
+	void setUp() {
+		props = new JwtProperties();
+		props.getJwt().setIssuer("heycalendar");
+		props.getJwt().setSecret(STRONG_SECRET);
+		props.getJwt().setAccessExpMin(30);     // 30분
+		props.getJwt().setRefreshExpDays(7);    // 7일
+		props.getJwt().setTokenPrefix("Bearer");
+		props.getJwt().setHeaderString("Authorization");
+
+		jwtUtil = new JwtUtil(props);
+		// @PostConstruct 대체 호출 (테스트에서 수동 초기화)
+		jwtUtil.init();
+	}
+
+	@Test
+	@DisplayName("AuthTokenService로 생성한 AccessToken을 JwtUtil로 parse → 한글 이름 클레임 검증")
+	void createAccessToken_via_service_and_parse_success() {
+		// AffiliationService 목: ID → 한글 이름 매핑 스텁
+		AffiliationService aff = mock(AffiliationService.class);
+		when(aff.getUniversityName(UNIV_ID)).thenReturn(UNIV_NAME);
+		when(aff.getCollegeName(UNIV_ID, COLLEGE_ID)).thenReturn(COLLEGE_NAME);
+		when(aff.getDepartmentName(UNIV_ID, COLLEGE_ID, DEPT_ID)).thenReturn(DEPT_NAME);
+
+		// 토큰 생성은 서비스에서 수행
+		AuthTokenService tokenService = new AuthTokenService(jwtUtil, props, aff);
+
+		String token = tokenService.createAccessToken(
+			"20250001",         // userNm -> sub
+			"alice",            // userId
+			"STUDENT",          // role
+			"홍길동",             // userName
+			DEPT_ID,            // deptNm (ID는 토큰에 들어가지 않음)
+			COLLEGE_ID,
+			UNIV_ID,
+			2                   // grade
+		);
+
+		Jws<Claims> jws = jwtUtil.parse(token);
+		Claims c = jws.getPayload();
+
+		assertThat(c.getIssuer()).isEqualTo("heycalendar");
+		assertThat(c.getSubject()).isEqualTo("20250001");
+		assertThat(c.get("typ", String.class)).isEqualTo("access");
+		assertThat(c.get("userId", String.class)).isEqualTo("alice");
+		assertThat(c.get("userName", String.class)).isEqualTo("홍길동");
+		assertThat(c.get("role", String.class)).isEqualTo("STUDENT");
+		assertThat(c.get("grade", Integer.class)).isEqualTo(2);
+
+		// ✅ 한글 이름만 들어간다
+		assertThat(c.get("univName", String.class)).isEqualTo(UNIV_NAME);
+		assertThat(c.get("collegeName", String.class)).isEqualTo(COLLEGE_NAME);
+		assertThat(c.get("deptName", String.class)).isEqualTo(DEPT_NAME);
+
+		// ✅ ID 키는 없어야 한다
+		assertThat(c.get("univNm")).isNull();
+		assertThat(c.get("collegeNm")).isNull();
+		assertThat(c.get("deptNm")).isNull();
+
+		assertThat(c.getExpiration()).isAfter(new Date());
+		assertThat(jwtUtil.isAccess(token)).isTrue();
+		assertThat(jwtUtil.isRefresh(token)).isFalse();
+		assertThat(jwtUtil.subjectUserNm(token)).isEqualTo("20250001");
+		assertThat(jwtUtil.validateToken(token)).isTrue();
+		assertThat(jwtUtil.isTokenExpired(token)).isFalse();
+	}
+
+	@Test
+	@DisplayName("subjectUserNm: Subject를 정확히 반환")
+	void subjectUserNm_returns_subject() {
+		// AffiliationService 목
+		AffiliationService aff = mock(AffiliationService.class);
+		when(aff.getUniversityName(UNIV_ID)).thenReturn(UNIV_NAME);
+
+		AuthTokenService tokenService = new AuthTokenService(jwtUtil, props, aff);
+
+		String token = tokenService.createAccessToken(
+			"kim-dev", "dev01", "ADMIN", "김개발",
+			DEPT_ID, COLLEGE_ID, UNIV_ID, 3
+		);
+
+		assertThat(jwtUtil.subjectUserNm(token)).isEqualTo("kim-dev");
+	}
+
+	@Test
+	@DisplayName("AuthTokenService로 생성한 RefreshToken → parse 성공 및 typ=refresh")
+	void createRefreshToken_via_service_and_parse_success() {
+		AffiliationService aff = mock(AffiliationService.class); // 사용 안 해도 생성자 필요
+		AuthTokenService tokenService = new AuthTokenService(jwtUtil, props, aff);
+
+		String token = tokenService.createRefreshToken("20250001", "jti-1234");
+
+		Jws<Claims> jws = jwtUtil.parse(token);
+		Claims c = jws.getPayload();
+
+		assertThat(c.getIssuer()).isEqualTo("heycalendar");
+		assertThat(c.getSubject()).isEqualTo("20250001");
+		assertThat(c.getId()).isEqualTo("jti-1234");
+		assertThat(c.get("typ", String.class)).isEqualTo("refresh");
+		assertThat(jwtUtil.isRefresh(token)).isTrue();
+		assertThat(jwtUtil.isAccess(token)).isFalse();
+		assertThat(jwtUtil.validateToken(token)).isTrue();
+	}
+
+	@Test
+	@DisplayName("validateToken: 형식이 잘못된 토큰은 false")
+	void validateToken_malformed_returns_false() {
+		String bad = "not.a.jwt.token";
+		assertThat(jwtUtil.validateToken(bad)).isFalse();
+	}
+
+	@Test
+	@DisplayName("isTokenExpired: 과거 만료시간으로 서명된 토큰은 만료로 판단")
+	void isTokenExpired_returns_true_for_expired_token() {
+		// JwtUtil의 기능만 검증(서비스 경유 X) - 과거 만료 토큰 직접 생성
+		SecretKey key = Keys.hmacShaKeyFor(STRONG_SECRET.getBytes(StandardCharsets.UTF_8));
+		Instant now = Instant.now();
+		Date issuedAt = Date.from(now.minusSeconds(3600)); // 1시간 전
+		Date expiredAt = Date.from(now.minusSeconds(10));  // 10초 전(이미 만료)
+
+		String expiredToken = Jwts.builder()
+			.issuer("heycalendar")
+			.subject("만료사용자")
+			.claims(Map.of("userId", "expired", "role", "STUDENT", "typ", "access"))
+			.issuedAt(issuedAt)
+			.expiration(expiredAt)
+			.signWith(key, Jwts.SIG.HS256)
+			.compact();
+
+		assertThat(jwtUtil.validateToken(expiredToken)).isFalse(); // 파싱 시 Expired로 판단
+		assertThat(jwtUtil.isTokenExpired(expiredToken)).isTrue();
+	}
+
+	@Test
+	@DisplayName("약한 시크릿(32바이트 미만) 사용 시 WeakKeyException 발생")
+	void weak_secret_throws_exception_on_init() {
+		JwtProperties weakProps = new JwtProperties();
+		weakProps.getJwt().setIssuer("heycalendar");
+		weakProps.getJwt().setSecret("too-short-secret"); // 32바이트 미만 → Weak
+		weakProps.getJwt().setAccessExpMin(5);
+		weakProps.getJwt().setRefreshExpDays(1);
+
+		JwtUtil util = new JwtUtil(weakProps);
+		assertThatThrownBy(util::init).isInstanceOf(WeakKeyException.class);
+	}
+}

--- a/apps/backend/src/test/java/com/solsol/heycalendar/service/AuthServiceTest.java
+++ b/apps/backend/src/test/java/com/solsol/heycalendar/service/AuthServiceTest.java
@@ -1,81 +1,98 @@
 package com.solsol.heycalendar.service;
 
 import com.solsol.heycalendar.domain.RefreshToken;
-import com.solsol.heycalendar.dto.request.AuthRequest;
+import com.solsol.heycalendar.domain.Role;
+import com.solsol.heycalendar.domain.User;
+import com.solsol.heycalendar.dto.request.*;
 import com.solsol.heycalendar.dto.response.AuthResponse;
 import com.solsol.heycalendar.mapper.RefreshTokenMapper;
 import com.solsol.heycalendar.mapper.UserMapper;
+import com.solsol.heycalendar.security.AuthTokenService;
 import com.solsol.heycalendar.security.CustomUserPrincipal;
 import com.solsol.heycalendar.security.JwtUtil;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
-import jakarta.servlet.http.HttpServletRequest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.util.Date;
+import java.util.Optional;
+import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 /**
- * AuthService.login()의 정상 발급 플로우를 검증하는 단위 테스트.
+ * AuthService 단위 테스트 (builder/getter만 사용)
  */
 @ExtendWith(org.mockito.junit.jupiter.MockitoExtension.class)
 class AuthServiceTest {
 
 	@Mock AuthenticationManager authenticationManager;
-	@Mock JwtUtil jwtUtil;
-	@Mock UserMapper userMapper;               // login()에서는 직접 사용 X (refresh()에서 사용)
+	@Mock JwtUtil jwtUtil; // 파싱/검증용
+	@Mock AuthTokenService authTokenService; // ✅ 토큰 생성 책임
+	@Mock UserMapper userMapper;
 	@Mock RefreshTokenMapper refreshTokenMapper;
+	@Mock PasswordEncoder passwordEncoder;
 
 	@InjectMocks AuthService authService;
 
 	@BeforeEach
 	void setupRequestContext() {
-		// AuthService.login() 내부에서 RequestContextHolder를 사용하므로 mock request 세팅
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addHeader("User-Agent", "JUnit");
 		request.setRemoteAddr("127.0.0.1");
 		RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
 	}
 
+	// ====== login() ======
 	@Test
-	@DisplayName("로그인 성공 시 액세스/리프레시 토큰을 발급하고 RefreshToken을 저장한다")
+	@DisplayName("로그인 성공 시 액세스/리프레시 토큰 발급 및 RefreshToken 저장")
 	void login_success() {
-		// given
 		AuthRequest req = AuthRequest.builder()
 			.userId("alice")
 			.password("password1!")
 			.build();
 
-		// CustomUserPrincipal mocking
 		CustomUserPrincipal principal = mock(CustomUserPrincipal.class);
-		when(principal.getUserNm()).thenReturn("20250001");  // 학번 String (B안)
+		when(principal.getUserNm()).thenReturn("20250001");
 		when(principal.getUserId()).thenReturn("alice");
-		when(principal.getRole()).thenReturn("STUDENT");     // enum이라면 getRole().name()으로 맞추세요
+		when(principal.getRole()).thenReturn("STUDENT");
+		when(principal.getUsername()).thenReturn("홍길동");
+		when(principal.getDeptNm()).thenReturn(3001L);
+		when(principal.getCollegeNm()).thenReturn(2001L);
+		when(principal.getUnivNm()).thenReturn(1001L);
+		when(principal.getGrade()).thenReturn(2);
 
 		Authentication auth = mock(Authentication.class);
 		when(auth.getPrincipal()).thenReturn(principal);
 		when(authenticationManager.authenticate(any(Authentication.class))).thenReturn(auth);
 
-		// JwtUtil 동작 mocking
-		when(jwtUtil.createAccessToken("20250001", "alice", "STUDENT"))
-			.thenReturn("ACCESS_TOKEN_EXAMPLE");
+		// ✅ 토큰 생성은 AuthTokenService로 스텁
+		when(authTokenService.createAccessToken(
+			eq("20250001"),
+			eq("alice"),
+			eq("STUDENT"),
+			eq("홍길동"),
+			eq(3001L),
+			eq(2001L),
+			eq(1001L),
+			eq(2)
+		)).thenReturn("ACCESS_TOKEN_EXAMPLE");
 
-		when(jwtUtil.createRefreshToken(eq("20250001"), anyString()))
+		when(authTokenService.createRefreshToken(eq("20250001"), anyString()))
 			.thenReturn("REFRESH_TOKEN_EXAMPLE");
 
-		// parse(refresh) → issuedAt/expiration 필요
+		// 🔐 refresh 토큰 파싱은 여전히 JwtUtil에서 수행
 		@SuppressWarnings("unchecked")
 		Jws<Claims> jws = (Jws<Claims>) mock(Jws.class);
 		Claims claims = mock(Claims.class);
@@ -84,15 +101,237 @@ class AuthServiceTest {
 		when(jws.getPayload()).thenReturn(claims);
 		when(jwtUtil.parse("REFRESH_TOKEN_EXAMPLE")).thenReturn(jws);
 
-		// when
 		AuthResponse res = authService.login(req);
 
-		// then
 		assertThat(res.getAccessToken()).isEqualTo("ACCESS_TOKEN_EXAMPLE");
 		assertThat(res.getRefreshToken()).isEqualTo("REFRESH_TOKEN_EXAMPLE");
-
-		// RefreshToken 저장 호출 검증
 		verify(refreshTokenMapper, times(1)).insert(any(RefreshToken.class));
 		verifyNoMoreInteractions(refreshTokenMapper);
+	}
+
+	// ====== refresh() ======
+	@Test
+	@DisplayName("refresh 성공: 기존 refresh 검증 → revoke → 신규 access/refresh 발급 및 저장 (확장 클레임 포함)")
+	void refresh_success() {
+		String oldJti = UUID.randomUUID().toString();
+		String oldRefresh = "OLD_REFRESH_TOKEN";
+
+		RefreshRequest req = RefreshRequest.builder()
+			.refreshToken(oldRefresh)
+			.build();
+
+		when(jwtUtil.validateToken(oldRefresh)).thenReturn(true);
+		when(jwtUtil.isRefresh(oldRefresh)).thenReturn(true);
+
+		@SuppressWarnings("unchecked")
+		Jws<Claims> oldJws = (Jws<Claims>) mock(Jws.class);
+		Claims oldClaims = mock(Claims.class);
+		when(oldClaims.getId()).thenReturn(oldJti);
+		when(oldJws.getPayload()).thenReturn(oldClaims);
+		when(jwtUtil.parse(oldRefresh)).thenReturn(oldJws);
+
+		RefreshToken active = RefreshToken.builder()
+			.userId("alice")
+			.userNm("20250001")
+			.token(oldJti)
+			.revoked(false)
+			.build();
+		when(refreshTokenMapper.findActiveByToken(oldJti)).thenReturn(active);
+
+		// User 엔티티는 목으로 처리 (getter만)
+		String userName = "홍길동";
+		Long deptNm = 3001L;
+		Long collegeNm = 2001L;
+		Long univNm = 1001L;
+		Integer grade = 2;
+
+		User user = mock(User.class);
+		when(user.getUserId()).thenReturn("alice");
+		when(user.getUserNm()).thenReturn("20250001");
+		when(user.getUserName()).thenReturn(userName);
+		when(user.getDeptNm()).thenReturn(deptNm);
+		when(user.getCollegeNm()).thenReturn(collegeNm);
+		when(user.getUnivNm()).thenReturn(univNm);
+		when(user.getGrade()).thenReturn(grade);
+		when(user.getRole()).thenReturn(Role.STUDENT);
+		when(userMapper.findByUserId("alice")).thenReturn(Optional.of(user));
+
+		when(authTokenService.createAccessToken(
+			eq("20250001"),
+			eq("alice"),
+			eq("STUDENT"),
+			eq(userName),
+			eq(deptNm),
+			eq(collegeNm),
+			eq(univNm),
+			eq(grade)
+		)).thenReturn("NEW_ACCESS");
+
+		// ✅ refresh 토큰 생성도 AuthTokenService
+		when(authTokenService.createRefreshToken(eq("20250001"), anyString()))
+			.thenReturn("NEW_REFRESH");
+
+		// 신규 refresh 파싱은 JwtUtil
+		@SuppressWarnings("unchecked")
+		Jws<Claims> newJws = (Jws<Claims>) mock(Jws.class);
+		Claims newClaims = mock(Claims.class);
+		when(newClaims.getIssuedAt()).thenReturn(new Date());
+		when(newClaims.getExpiration()).thenReturn(new Date(System.currentTimeMillis() + 3_600_000));
+		when(newJws.getPayload()).thenReturn(newClaims);
+		when(jwtUtil.parse("NEW_REFRESH")).thenReturn(newJws);
+
+		AuthResponse res = authService.refresh(req);
+
+		assertThat(res.getAccessToken()).isEqualTo("NEW_ACCESS");
+		assertThat(res.getRefreshToken()).isEqualTo("NEW_REFRESH");
+		verify(refreshTokenMapper).revokeByToken(oldJti);
+		verify(refreshTokenMapper).insert(any(RefreshToken.class));
+	}
+
+	@Test
+	@DisplayName("refresh 실패: 토큰이 유효하지 않으면 예외")
+	void refresh_fail_invalid_token() {
+		RefreshRequest req = RefreshRequest.builder()
+			.refreshToken("BAD")
+			.build();
+
+		when(jwtUtil.validateToken("BAD")).thenReturn(false);
+
+		assertThatThrownBy(() -> authService.refresh(req))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessageContaining("Invalid Refresh Token");
+		verify(refreshTokenMapper, never()).insert(any());
+	}
+
+	@Test
+	@DisplayName("refresh 실패: DB에 활성 토큰이 없으면 예외")
+	void refresh_fail_not_found_in_db() {
+		String oldRefresh = "OLD_REFRESH";
+		String oldJti = "old-jti";
+		RefreshRequest req = RefreshRequest.builder()
+			.refreshToken(oldRefresh)
+			.build();
+
+		when(jwtUtil.validateToken(oldRefresh)).thenReturn(true);
+		when(jwtUtil.isRefresh(oldRefresh)).thenReturn(true);
+
+		@SuppressWarnings("unchecked") Jws<Claims> jws = (Jws<Claims>) mock(Jws.class);
+		Claims claims = mock(Claims.class);
+		when(claims.getId()).thenReturn(oldJti);
+		when(jws.getPayload()).thenReturn(claims);
+		when(jwtUtil.parse(oldRefresh)).thenReturn(jws);
+
+		when(refreshTokenMapper.findActiveByToken(oldJti)).thenReturn(null);
+
+		assertThatThrownBy(() -> authService.refresh(req))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessageContaining("not found or revoked");
+		verify(refreshTokenMapper, never()).insert(any());
+	}
+
+	// ====== logout() ======
+	@Test
+	@DisplayName("logout: 유효한 리프레시 토큰이면 revokeByToken 호출")
+	void logout_valid_refresh_revokes() {
+		String refresh = "REFRESH";
+		String jti = "jti-123";
+
+		LogoutRequest req = LogoutRequest.builder()
+			.refreshToken(refresh)
+			.build();
+
+		when(jwtUtil.validateToken(refresh)).thenReturn(true);
+		when(jwtUtil.isRefresh(refresh)).thenReturn(true);
+
+		@SuppressWarnings("unchecked") Jws<Claims> jws = (Jws<Claims>) mock(Jws.class);
+		Claims claims = mock(Claims.class);
+		when(claims.getId()).thenReturn(jti);
+		when(jws.getPayload()).thenReturn(claims);
+		when(jwtUtil.parse(refresh)).thenReturn(jws);
+
+		authService.logout(req);
+
+		verify(refreshTokenMapper).revokeByToken(jti);
+	}
+
+	@Test
+	@DisplayName("logout: 무효 토큰/예외 발생 시 무시")
+	void logout_ignores_invalid() {
+		LogoutRequest req = LogoutRequest.builder()
+			.refreshToken("X")
+			.build();
+
+		when(jwtUtil.validateToken("X")).thenReturn(false);
+
+		authService.logout(req);
+
+		verify(refreshTokenMapper, never()).revokeByToken(anyString());
+	}
+
+	// ====== requestPasswordReset() ======
+	@Test
+	@DisplayName("requestPasswordReset: 사용자 존재 시 userKey 업데이트 성공")
+	void requestPasswordReset_success() {
+		PasswordResetRequest req = PasswordResetRequest.builder()
+			.userId("alice")
+			.build();
+
+		when(userMapper.findByUserId("alice")).thenReturn(Optional.of(mock(User.class)));
+		when(userMapper.updateUserKeyByUserId(eq("alice"), anyString())).thenReturn(1);
+
+		authService.requestPasswordReset(req);
+
+		verify(userMapper).updateUserKeyByUserId(eq("alice"), anyString());
+	}
+
+	@Test
+	@DisplayName("requestPasswordReset: 사용자 없으면 UsernameNotFoundException")
+	void requestPasswordReset_user_not_found() {
+		PasswordResetRequest req = PasswordResetRequest.builder()
+			.userId("nope")
+			.build();
+
+		when(userMapper.findByUserId("nope")).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> authService.requestPasswordReset(req))
+			.isInstanceOf(UsernameNotFoundException.class);
+	}
+
+	// ====== confirmPasswordReset() ======
+	@Test
+	@DisplayName("confirmPasswordReset: 토큰 유효 → 비밀번호 변경, userKey 클리어, 모든 refresh revoke")
+	void confirmPasswordReset_success() {
+		PasswordResetConfirmRequest req = PasswordResetConfirmRequest.builder()
+			.token("T-123456")
+			.newPassword("NewP@ssw0rd!")
+			.build();
+
+		User user = mock(User.class);
+		when(user.getUserId()).thenReturn("alice");
+		when(user.getUserNm()).thenReturn("20250001");
+
+		when(userMapper.findByUserKey("T-123456")).thenReturn(Optional.of(user));
+		when(passwordEncoder.encode("NewP@ssw0rd!")).thenReturn("ENC");
+		when(userMapper.updatePasswordByUserId("alice", "ENC")).thenReturn(1);
+
+		authService.confirmPasswordReset(req);
+
+		verify(userMapper).clearUserKeyByUserKey("T-123456");
+		verify(refreshTokenMapper).revokeAllByUserNm("20250001");
+	}
+
+	@Test
+	@DisplayName("confirmPasswordReset: 토큰 불일치/만료 → IllegalArgumentException")
+	void confirmPasswordReset_invalid_token() {
+		PasswordResetConfirmRequest req = PasswordResetConfirmRequest.builder()
+			.token("BAD")
+			.newPassword("x")
+			.build();
+
+		when(userMapper.findByUserKey("BAD")).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> authService.confirmPasswordReset(req))
+			.isInstanceOf(IllegalArgumentException.class);
+		verify(userMapper, never()).updatePasswordByUserId(anyString(), anyString());
 	}
 }

--- a/apps/backend/src/test/java/com/solsol/heycalendar/service/AuthServiceTest.java
+++ b/apps/backend/src/test/java/com/solsol/heycalendar/service/AuthServiceTest.java
@@ -1,0 +1,98 @@
+package com.solsol.heycalendar.service;
+
+import com.solsol.heycalendar.domain.RefreshToken;
+import com.solsol.heycalendar.dto.request.AuthRequest;
+import com.solsol.heycalendar.dto.response.AuthResponse;
+import com.solsol.heycalendar.mapper.RefreshTokenMapper;
+import com.solsol.heycalendar.mapper.UserMapper;
+import com.solsol.heycalendar.security.CustomUserPrincipal;
+import com.solsol.heycalendar.security.JwtUtil;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * AuthService.login()의 정상 발급 플로우를 검증하는 단위 테스트.
+ */
+@ExtendWith(org.mockito.junit.jupiter.MockitoExtension.class)
+class AuthServiceTest {
+
+	@Mock AuthenticationManager authenticationManager;
+	@Mock JwtUtil jwtUtil;
+	@Mock UserMapper userMapper;               // login()에서는 직접 사용 X (refresh()에서 사용)
+	@Mock RefreshTokenMapper refreshTokenMapper;
+
+	@InjectMocks AuthService authService;
+
+	@BeforeEach
+	void setupRequestContext() {
+		// AuthService.login() 내부에서 RequestContextHolder를 사용하므로 mock request 세팅
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("User-Agent", "JUnit");
+		request.setRemoteAddr("127.0.0.1");
+		RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+	}
+
+	@Test
+	@DisplayName("로그인 성공 시 액세스/리프레시 토큰을 발급하고 RefreshToken을 저장한다")
+	void login_success() {
+		// given
+		AuthRequest req = AuthRequest.builder()
+			.userId("alice")
+			.password("password1!")
+			.build();
+
+		// CustomUserPrincipal mocking
+		CustomUserPrincipal principal = mock(CustomUserPrincipal.class);
+		when(principal.getUserNm()).thenReturn("20250001");  // 학번 String (B안)
+		when(principal.getUserId()).thenReturn("alice");
+		when(principal.getRole()).thenReturn("STUDENT");     // enum이라면 getRole().name()으로 맞추세요
+
+		Authentication auth = mock(Authentication.class);
+		when(auth.getPrincipal()).thenReturn(principal);
+		when(authenticationManager.authenticate(any(Authentication.class))).thenReturn(auth);
+
+		// JwtUtil 동작 mocking
+		when(jwtUtil.createAccessToken("20250001", "alice", "STUDENT"))
+			.thenReturn("ACCESS_TOKEN_EXAMPLE");
+
+		when(jwtUtil.createRefreshToken(eq("20250001"), anyString()))
+			.thenReturn("REFRESH_TOKEN_EXAMPLE");
+
+		// parse(refresh) → issuedAt/expiration 필요
+		@SuppressWarnings("unchecked")
+		Jws<Claims> jws = (Jws<Claims>) mock(Jws.class);
+		Claims claims = mock(Claims.class);
+		when(claims.getIssuedAt()).thenReturn(new Date());
+		when(claims.getExpiration()).thenReturn(new Date(System.currentTimeMillis() + 3_600_000));
+		when(jws.getPayload()).thenReturn(claims);
+		when(jwtUtil.parse("REFRESH_TOKEN_EXAMPLE")).thenReturn(jws);
+
+		// when
+		AuthResponse res = authService.login(req);
+
+		// then
+		assertThat(res.getAccessToken()).isEqualTo("ACCESS_TOKEN_EXAMPLE");
+		assertThat(res.getRefreshToken()).isEqualTo("REFRESH_TOKEN_EXAMPLE");
+
+		// RefreshToken 저장 호출 검증
+		verify(refreshTokenMapper, times(1)).insert(any(RefreshToken.class));
+		verifyNoMoreInteractions(refreshTokenMapper);
+	}
+}


### PR DESCRIPTION
## 개요 (What)  
사용자 로그인 및 인증 기능 구현

- JWT 기반 액세스/리프레시 토큰 발급 및 관리  
- 비밀번호 재설정(요청/확정) 로직 추가  
- 로그아웃 및 토큰 순환(refresh) 처리  

---

## 작업 내용 (What I did)  

### AuthService  
- `login`: ID/비밀번호 인증 → AccessToken + RefreshToken 발급  
- `refresh`: 리프레시 토큰 검증 → 토큰 순환 발급 및 DB 업데이트  
- `logout`: 리프레시 토큰 무효화  
- `requestPasswordReset`: 임시 코드 생성 및 저장  
- `confirmPasswordReset`: 코드 검증 후 비밀번호 변경 및 기존 토큰 무효화  

### JWT 구조 개선  
- `JwtUtil`: 서명/파싱/검증 전담  
- `AuthTokenService`: 액세스/리프레시 토큰 생성 책임 분리  
  - 액세스 토큰 → userId, role, 이름/학부/학과 등 클레임 포함  
  - 리프레시 토큰 → jti(UUID) 포함, DB 관리  

### UserMapper 정리  
- 불필요 메서드 제거, 실제 사용하는 메서드만 유지  
- `gpa` 타입을 BigDecimal로 정리 (DB DECIMAL(3,2)와 일치)  

### RefreshToken 관리  
- DB 저장 및 jti 기반 블랙리스트 처리  
- 토큰 회전 시 기존 토큰 무효화 후 신규 발급  

### 테스트 코드  
- `AuthServiceTest`: createAccessToken 인자 순서(role → userName) 수정  
- `JwtUtilTest`: AuthTokenService와 분리하여 검증 로직 리팩토링  
- 한글 클레임(univName/collegeName/deptName) 처리 검증  

---

## 🔁 테스트 및 검토 사항  
- [x] 로그인 성공/실패 케이스 검증  
- [x] 리프레시 토큰 만료/무효화 시 재발급 불가 확인  
- [x] 로그아웃 시 토큰 블랙리스트 처리 확인  
- [x] 비밀번호 재설정 요청/확정 플로우 정상 동작 확인  
- [x] 단위 테스트 통과 (AuthServiceTest, JwtUtilTest)  
